### PR TITLE
Fine-tune caching behavior

### DIFF
--- a/VentoPlugin.js
+++ b/VentoPlugin.js
@@ -115,6 +115,10 @@ export function VentoPlugin(eleventyConfig, options = {}) {
 
 				const result = await env.runString(inputContent, data, inputPath);
 
+				if (data.page?.rawInput !== inputContent) {
+					env.cache.delete(inputPath);
+				}
+
 				return result.content;
 			};
 		},

--- a/VentoPlugin.js
+++ b/VentoPlugin.js
@@ -82,10 +82,13 @@ export function VentoPlugin(eleventyConfig, options = {}) {
 	// Add vto as a template format and create a custom template for it
 	eleventyConfig.addTemplateFormats('vto');
 	eleventyConfig.addExtension('vto', {
+		// Set output extension
 		outputFileExtension: 'html',
 
+		// Read vto files into eleventy
 		read: true,
 
+		// Main compile function
 		async compile(inputContent, inputPath) {
 			return async (data) => {
 				if (options.addHelpers) {
@@ -124,6 +127,7 @@ export function VentoPlugin(eleventyConfig, options = {}) {
 		},
 
 		compileOptions: {
+			// Custom permalink compilation
 			permalink(linkContents) {
 				if (typeof linkContents !== 'string') return linkContents;
 				return async (data) => {

--- a/tests/engine-overrides/__snapshots__/as-html-engine.html
+++ b/tests/engine-overrides/__snapshots__/as-html-engine.html
@@ -1,0 +1,4 @@
+
+<p>2 + 2 = 4</p>
+
+<p>This is a cool page</p>

--- a/tests/engine-overrides/__snapshots__/as-md-engine.html
+++ b/tests/engine-overrides/__snapshots__/as-md-engine.html
@@ -1,0 +1,2 @@
+<p>2 + 2 = 4</p>
+<p>This is a cool page</p>

--- a/tests/engine-overrides/as-html-engine.html
+++ b/tests/engine-overrides/as-html-engine.html
@@ -1,0 +1,7 @@
+---
+title: This is a cool page
+---
+
+<p>2 + 2 = {{ 2 + 2 }}</p>
+
+<p>{{ title }}</p>

--- a/tests/engine-overrides/as-md-engine.md
+++ b/tests/engine-overrides/as-md-engine.md
@@ -1,0 +1,7 @@
+---
+title: This is a cool page
+---
+
+2 + 2 = {{ 2 + 2 }}
+
+{{ title }}

--- a/tests/engine-overrides/eleventy.config.js
+++ b/tests/engine-overrides/eleventy.config.js
@@ -1,0 +1,4 @@
+export const config = {
+	markdownTemplateEngine: 'vto',
+	htmlTemplateEngine: 'vto',
+};

--- a/tests/engine-overrides/engine-overrides.test.js
+++ b/tests/engine-overrides/engine-overrides.test.js
@@ -1,0 +1,14 @@
+import { expect, test } from 'vitest';
+import { runBuild } from '#test-instance';
+
+export const results = await runBuild(import.meta.dirname);
+
+test('renders markdown file with Vento', async () => {
+	const page = results.find(({ url }) => url === '/as-md-engine/');
+	await expect(page.content).toMatchFileSnapshot('./__snapshots__/as-md-engine.html');
+});
+
+test('renders html file with Vento', async () => {
+	const page = results.find(({ url }) => url === '/as-html-engine/');
+	await expect(page.content).toMatchFileSnapshot('./__snapshots__/as-html-engine.html');
+});


### PR DESCRIPTION
Fixes #10.

This pull implements a patch that clears the Vento cache for a given `inputPath` when `rawContent` doesn't match `inputContent`, or isn't defined at all. The delete executes after the template is compiled and allows template content to be compiled without pulling from previously compiled `permalink` or `eleventyComputed` values.

There may be more of these in the future so more issues/pulls may need to be opened to address those when caught. For now, this should suffice.